### PR TITLE
Add checks on linux for folders with spaces in the name

### DIFF
--- a/profile/mesasdk-aarch64-linux/init_scripts/init.sh
+++ b/profile/mesasdk-aarch64-linux/init_scripts/init.sh
@@ -7,6 +7,12 @@ if [[ -z "$MESASDK_ROOT" ]]; then
     return 1
 fi
 
+if [[ "$MESASDK_ROOT" == *" "* ]]; then
+    echo "mesasdk_init.sh: MESASDK_ROOT can not contain spaces"
+    echo "mesasdk_init.sh: Please move your sdk to a folder without spaces in the full path name"
+    return 1
+fi
+
 # Check architecture
 
 if [ ! -f "${MESASDK_ROOT}/etc/check_arch.done" ]; then

--- a/profile/mesasdk-x86_64-linux-dev/init_scripts/init.sh
+++ b/profile/mesasdk-x86_64-linux-dev/init_scripts/init.sh
@@ -7,6 +7,12 @@ if [[ -z "$MESASDK_ROOT" ]]; then
     return 1
 fi
 
+if [[ "$MESASDK_ROOT" == *" "* ]]; then
+    echo "mesasdk_init.sh: MESASDK_ROOT can not contain spaces"
+    echo "mesasdk_init.sh: Please move your sdk to a folder without spaces in the full path name"
+    return 1
+fi
+
 # Check architecture
 
 if [ ! -f "${MESASDK_ROOT}/etc/check_arch.done" ]; then

--- a/profile/mesasdk-x86_64-linux/init_scripts/init.sh
+++ b/profile/mesasdk-x86_64-linux/init_scripts/init.sh
@@ -7,6 +7,12 @@ if [[ -z "$MESASDK_ROOT" ]]; then
     return 1
 fi
 
+if [[ "$MESASDK_ROOT" == *" "* ]]; then
+    echo "mesasdk_init.sh: MESASDK_ROOT can not contain spaces"
+    echo "mesasdk_init.sh: Please move your sdk to a folder without spaces in the full path name"
+    return 1
+fi
+
 # Check architecture
 
 if [ ! -f "${MESASDK_ROOT}/etc/check_arch.done" ]; then


### PR DESCRIPTION
Given that makefile's can not handle spaces there's no point going through and quoting everything. So lets just error out if MESASDK_ROOT contains a spaces.